### PR TITLE
Fix issue causing factor not to be displayed when 0

### DIFF
--- a/site/src/Infobytes/templates/InfobyteEditor.svelte
+++ b/site/src/Infobytes/templates/InfobyteEditor.svelte
@@ -38,10 +38,13 @@
       $form.frontmatter = selectedInfobyte.frontmatter || "";
       $form._id = selectedInfobyte._id || "";
       $form.aspect = selectedInfobyte.aspect || "";
-      $form.factor = selectedInfobyte.factor || "";
+      $form.factor =
+        selectedInfobyte.factor !== null &&
+        selectedInfobyte.factor !== undefined
+          ? selectedInfobyte.factor
+          : "";
       $form.difficulty = selectedInfobyte.difficulty || 0;
       $form.position = selectedInfobyte.position || 0;
-
     }
   }
 


### PR DESCRIPTION
Hey, truthy in JS/TS ist echt so eine Sache.

`$form.factor = selectedInfobyte.factor || "";`

find ich zwar auch elegant - aber ist echt ein Problem. `selectedInfobyte.factor `ist nämlich nicht truthy wenn der Wert "0" ist. :/ d.h eigentlich sollte man meistens explizit `null` und `undefined` abfangen statt mit truthy zu arbeiten.

Gruß